### PR TITLE
Fix approve status bug

### DIFF
--- a/app/backend/src/moderator/moderator.service.ts
+++ b/app/backend/src/moderator/moderator.service.ts
@@ -6,7 +6,7 @@ import {
 } from '@nestjs/common';
 import { CreateModeratorDto } from './dto/create_moderator.dto';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { IsNull, Repository } from 'typeorm';
 import { Moderator } from './entities/moderator.entity';
 import { MailerService } from '@nestjs-modules/mailer';
 import { JwtService } from '@nestjs/jwt';
@@ -142,7 +142,7 @@ export class ModeratorService {
   public async fetchUnapprovedPolls(): Promise<Poll[]> {
     return await this.pollRepository.find({
       where: {
-        approveStatus: false,
+        approveStatus: IsNull(),
       },
       relations: ['options', 'tags', 'creator'],
     });

--- a/app/backend/src/poll/entities/poll.entity.ts
+++ b/app/backend/src/poll/entities/poll.entity.ts
@@ -76,7 +76,7 @@ export class Poll {
   //@Column({ nullable: true })
   //report_list: Array<any>;
 
-  @Column({ default: false })
+  @Column({ nullable: true })
   approveStatus: boolean;
 
   @Column('int', { default: Settle.ACTIVE })


### PR DESCRIPTION
Default approve status set the null instead false. Updated accordingly the fetch endpoint of unapproved polls.