### PR TITLE
Add sorting option to poll fetching

### DIFF
--- a/app/backend/src/poll/enums/settle.enum.ts
+++ b/app/backend/src/poll/enums/settle.enum.ts
@@ -1,6 +1,6 @@
 export enum Settle {
-    ACTIVE,
-    PENDING,
-    SETTLED,
-    CANCELLED,
+  ACTIVE,
+  PENDING,
+  SETTLED,
+  CANCELLED,
 }

--- a/app/backend/src/poll/enums/sort.enum.ts
+++ b/app/backend/src/poll/enums/sort.enum.ts
@@ -1,0 +1,4 @@
+export enum Sort {
+  ASC = 'ASC',
+  DESC = 'DESC',
+}

--- a/app/backend/src/poll/poll.controller.ts
+++ b/app/backend/src/poll/poll.controller.ts
@@ -95,6 +95,7 @@ export class PollController {
   @ApiQuery({ name: 'approveStatus', required: false })
   @ApiQuery({ name: 'likedById', required: false })
   @ApiQuery({ name: 'followedById', required: false })
+  @ApiQuery({ name: 'sort', required: false })
   @ApiResponse({
     status: 200,
     description: 'Polls are fetched successfully.',
@@ -114,12 +115,15 @@ export class PollController {
     likedById?: string,
     @Query('followedById', new ParseUUIDPipe({ optional: true }))
     followedById?: string,
+    @Query('sort')
+    sortString?: string,
   ): Promise<any> {
     return await this.pollService.findAll({
       creatorId,
       approveStatus,
       likedById,
       followedById,
+      sortString,
     });
   }
 
@@ -142,6 +146,7 @@ export class PollController {
       approveStatus: null,
       likedById: null,
       followedById: null,
+      sortString: null,
     });
   }
 
@@ -163,6 +168,7 @@ export class PollController {
       approveStatus: null,
       likedById: userId,
       followedById: null,
+      sortString: null,
     });
   }
 
@@ -184,6 +190,7 @@ export class PollController {
       approveStatus: null,
       likedById: null,
       followedById: userId,
+      sortString: null,
     });
   }
 

--- a/app/backend/src/poll/poll.module.ts
+++ b/app/backend/src/poll/poll.module.ts
@@ -16,7 +16,18 @@ import { Like } from '../like/entities/like.entity';
 import { Comment } from '../comment/entities/comment.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Poll, Option, Tag, User, Badge, Moderator,Like,Comment])],
+  imports: [
+    TypeOrmModule.forFeature([
+      Poll,
+      Option,
+      Tag,
+      User,
+      Badge,
+      Moderator,
+      Like,
+      Comment,
+    ]),
+  ],
   controllers: [PollController],
   providers: [
     PollService,

--- a/app/backend/src/poll/poll.service.ts
+++ b/app/backend/src/poll/poll.service.ts
@@ -13,6 +13,7 @@ import { User } from '../user/entities/user.entity';
 import { Settle } from './enums/settle.enum';
 import { SettlePollRequestDto } from './dto/settle-poll-request.dto';
 import { Like } from '../like/entities/like.entity';
+import { Sort } from './enums/sort.enum';
 
 @Injectable()
 export class PollService {
@@ -130,12 +131,19 @@ export class PollService {
     approveStatus,
     likedById,
     followedById,
+    sortString,
   }): Promise<Poll[]> {
+    if (sortString) {
+      if (!Object.values(Sort).includes(sortString)) {
+        throw new BadRequestException("Sort should be 'ASC' or 'DESC'");
+      }
+    }
     return await this.pollRepository.findAll({
       creatorId,
       approveStatus,
       likedById,
       followedById,
+      sortString,
     });
   }
 

--- a/app/backend/src/poll/repository/poll.repository.ts
+++ b/app/backend/src/poll/repository/poll.repository.ts
@@ -22,6 +22,7 @@ export class PollRepository extends Repository<Poll> {
     approveStatus,
     likedById,
     followedById,
+    sortString,
   }): Promise<Poll[]> {
     const queryBuilder = this.createQueryBuilder('poll');
 
@@ -39,6 +40,10 @@ export class PollRepository extends Repository<Poll> {
       queryBuilder
         .innerJoin('likes', 'like', 'like.pollId = poll.id')
         .andWhere('like.userId = :likedById', { likedById });
+    }
+
+    if (sortString) {
+      queryBuilder.orderBy('poll.creation_date', sortString);
     }
 
     if (followedById) {


### PR DESCRIPTION
I implemented sorting option to polls. Now, frontend and mobile teams can fetch polls based on whether they want them sorted in ascending order, descending order or random.