### PR TITLE
Be 629/get annotations from pollids

### DIFF
--- a/.github/workflows/annotation-server-deploy.yml
+++ b/.github/workflows/annotation-server-deploy.yml
@@ -34,3 +34,4 @@ jobs:
             docker rmi pollup:annotation-server-image
             docker build -t pollup:annotation-server-image .
             docker run --name annotation-server -p 1938:3001 -d pollup:annotation-server-image
+            docker system prune

--- a/.github/workflows/annotation-server-deploy.yml
+++ b/.github/workflows/annotation-server-deploy.yml
@@ -33,4 +33,4 @@ jobs:
             docker rm annotation-server
             docker rmi pollup:annotation-server-image
             docker build -t pollup:annotation-server-image .
-            docker run --name annotation-server -p 1924:3001 -d pollup:annotation-server-image
+            docker run --name annotation-server -p 1938:3001 -d pollup:annotation-server-image

--- a/app/annotation-server/.dockerignore
+++ b/app/annotation-server/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/app/annotation-server/src/controllers/annotation.controller.js
+++ b/app/annotation-server/src/controllers/annotation.controller.js
@@ -2,9 +2,18 @@ const annotationService = require("../services/annotation.service");
 
 async function getAnnotations(req, res) {
   try {
-    const { pollId } = req.query;
-    const annotations = await annotationService.getAnnotations(pollId);
-    return res.status(200).json({ annotations: annotations });
+    let { pollIDs } = req.query;
+    if (pollIDs) {
+      pollIDs = pollIDs.split(",");
+      const promises = pollIDs.map((pollId) =>
+        annotationService.getAnnotations(pollId)
+      );
+      const responses = await Promise.all(promises);
+      return res.status(200).json({ annotations: [].concat(...responses) });
+    } else {
+      const annotations = await annotationService.getAnnotations(pollIDs);
+      return res.status(200).json({ annotations: annotations });
+    }
   } catch (e) {
     console.error("Error getting annotations", e);
     res.status(500).json({ error: "An internal server error occurred." });

--- a/app/annotation-server/src/routes/annotation.route.js
+++ b/app/annotation-server/src/routes/annotation.route.js
@@ -49,8 +49,8 @@ router.get(
  *    summary: Get all annotations with query parameter
  *    parameters:
  *    - in: query
- *      name: pollId
- *      description: Get annotations for a specific poll
+ *      name: pollIDs
+ *      description: Get annotations for a specific set of polls
  *      required: false
  *      schema:
  *        type: string


### PR DESCRIPTION
I implemented the necessary. feature. Now, we accept a query parameter again. But this time, we extract poll Ids one by one and return the response for each of them. Therefore we can accept more than one source Id. We cannot accept a direct array parameter because get requests accepts only string parameters.