### PR TITLE
Extend poll functionalities

### DIFF
--- a/app/backend/src/poll/poll.controller.ts
+++ b/app/backend/src/poll/poll.controller.ts
@@ -154,6 +154,7 @@ export class PollController {
   @ApiQuery({ name: 'likedById', required: false })
   @ApiQuery({ name: 'votedById', required: false })
   @ApiQuery({ name: 'followedById', required: false })
+  @ApiQuery({ name: 'is_settled', required: false })
   @ApiQuery({ name: 'sort', required: false })
   @ApiQuery({ name: 'tags', required: false })
   @ApiResponse({
@@ -176,6 +177,8 @@ export class PollController {
     votedById?: string,
     @Query('followedById', new ParseUUIDPipe({ optional: true }))
     followedById?: string,
+    @Query('is_settled', new ParseIntPipe({ optional: true }))
+    is_settled?: string,
     @Query('sort')
     sortString?: string,
     @Query('tags', new ParseArrayPipe({ optional: true }))
@@ -190,6 +193,7 @@ export class PollController {
       followedById,
       sortString,
       tags,
+      is_settled,
       userId,
     });
   }
@@ -199,6 +203,7 @@ export class PollController {
   @ApiQuery({ name: 'creatorId', required: false })
   @ApiQuery({ name: 'likedById', required: false })
   @ApiQuery({ name: 'votedById', required: false })
+  @ApiQuery({ name: 'is_settled', required: false })
   @ApiQuery({ name: 'followedById', required: false })
   @ApiQuery({ name: 'sort', required: false })
   @ApiQuery({ name: 'tags', required: false })
@@ -226,6 +231,8 @@ export class PollController {
     votedById?: string,
     @Query('followedById', new ParseUUIDPipe({ optional: true }))
     followedById?: string,
+    @Query('is_settled', new ParseIntPipe({ optional: true }))
+    is_settled?: string,
     @Query('sort')
     sortString?: string,
     @Query('tags', new ParseArrayPipe({ optional: true }))
@@ -240,6 +247,7 @@ export class PollController {
       followedById,
       sortString,
       tags,
+      is_settled,
       userId,
       pageSize,
       pageNum,
@@ -268,6 +276,7 @@ export class PollController {
       followedById: null,
       sortString: null,
       tags: null,
+      is_settled: 0,
       userId: creatorId,
     });
   }
@@ -301,6 +310,7 @@ export class PollController {
       followedById: null,
       sortString: null,
       tags: null,
+      is_settled: 0,
       userId: creatorId,
       pageSize,
       pageNum,
@@ -353,6 +363,7 @@ export class PollController {
       votedById: null,
       followedById: null,
       sortString: null,
+      is_settled: 0,
       tags: null,
       userId,
     });
@@ -387,6 +398,7 @@ export class PollController {
       followedById: null,
       sortString: null,
       tags: null,
+      is_settled: 0,
       userId,
       pageSize,
       pageNum,
@@ -413,6 +425,7 @@ export class PollController {
       votedById: userId,
       followedById: null,
       sortString: null,
+      is_settled: 0,
       tags: null,
       userId,
     });
@@ -447,6 +460,7 @@ export class PollController {
       followedById: null,
       sortString: null,
       tags: null,
+      is_settled: 0,
       userId,
       pageSize,
       pageNum,
@@ -517,6 +531,7 @@ export class PollController {
       votedById: null,
       followedById: userId,
       sortString: null,
+      is_settled: 0,
       tags: null,
       userId,
     });
@@ -551,6 +566,7 @@ export class PollController {
       followedById: userId,
       sortString: null,
       tags: null,
+      is_settled: 0,
       userId,
       pageSize,
       pageNum,

--- a/app/backend/src/poll/poll.service.ts
+++ b/app/backend/src/poll/poll.service.ts
@@ -201,6 +201,7 @@ export class PollService {
     followedById,
     tags,
     sortString,
+    is_settled,
     userId,
   }) {
     const whereClause: any = {};
@@ -213,6 +214,10 @@ export class PollService {
 
     if (approveStatus != null) {
       whereClause.approveStatus = approveStatus;
+    }
+
+    if (is_settled != null) {
+      whereClause.is_settled = is_settled;
     }
 
     if (likedById) {
@@ -267,7 +272,7 @@ export class PollService {
         tags.every((tag) => poll.tags.some((tagItem) => tagItem.name === tag)),
       );
     }
-    
+
     let extendedPolls = await Promise.all(
       polls.map(async (poll) => {
         return {
@@ -277,29 +282,30 @@ export class PollService {
           voteCount: await this.voteService.getVoteCount(poll.id),
           votedOption: null,
           didLike: null,
-          voteDistribution: poll.is_settled === Settle.SETTLED ? await this.voteService.getVoteRate(poll.id) : null
+          voteDistribution:
+            poll.is_settled === Settle.SETTLED
+              ? await this.voteService.getVoteRate(poll.id)
+              : null,
         };
-      })
+      }),
     );
 
-    if(userId){
+    if (userId) {
       extendedPolls = await Promise.all(
         extendedPolls.map(async (poll) => {
-          const votedOption = (await this.voteService.findOne(poll.id, userId))?.option ?? null;
+          const votedOption =
+            (await this.voteService.findOne(poll.id, userId))?.option ?? null;
           if (!poll.voteDistribution && votedOption) {
             poll.voteDistribution = await this.voteService.getVoteRate(poll.id);
           }
           return {
             ...poll,
-            votedOption:votedOption,
+            votedOption: votedOption,
             didLike: poll.likes.some((like) => like.user?.id === userId),
           };
-        })
-      );      
+        }),
+      );
     }
-
-
-
 
     return extendedPolls;
   }
@@ -308,6 +314,8 @@ export class PollService {
     const polls = await this.pollRepository.find({
       where: [
         {
+          approveStatus: true,
+          is_settled: 0,
           votes: {
             user: {
               id: Not(voterId),
@@ -315,6 +323,8 @@ export class PollService {
           },
         },
         {
+          approveStatus: true,
+          is_settled: 0,
           votes: {
             user: {
               id: IsNull(),
@@ -362,6 +372,7 @@ export class PollService {
     followedById,
     tags,
     sortString,
+    is_settled,
     userId,
     pageSize,
     pageNum,
@@ -376,6 +387,10 @@ export class PollService {
 
     if (approveStatus != null) {
       whereClause.approveStatus = approveStatus;
+    }
+
+    if (is_settled != null) {
+      whereClause.is_settled = is_settled;
     }
 
     if (likedById) {
@@ -541,8 +556,9 @@ export class PollService {
       throw new NotFoundException('Poll not found');
     }
 
-    const votedOption = (await this.voteService.findOne(poll.id, userId))?.option || null;
-  
+    const votedOption =
+      (await this.voteService.findOne(poll.id, userId))?.option || null;
+
     let voteDistribution = null;
     if (votedOption) {
       voteDistribution = await this.voteService.getVoteRate(pollId);


### PR DESCRIPTION
I fixed some bugs related to poll fetching endpoints. Now, we have one more query parameter and fetch only not settled polls. This default setting can be overwritten by. the query parameter.